### PR TITLE
Bump user-agent string to latest ChromeOS

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,5 +1,5 @@
 const CHROMEOS_UAS =
-  "Mozilla/5.0 (X11; CrOS x86_64 10066.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4469.4 Safari/537.36";
+  "Mozilla/5.0 (X11; CrOS x86_64 16181.61.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.6998.198 Safari/537.36";
 
 const scriptTag = document.createElement("script");
 scriptTag.type = "text/javascript";


### PR DESCRIPTION
Hello,

The version listed in the add-on is no longer supported by Slack. This PR bumps it to the latest ChromeOS version.